### PR TITLE
Fixed link in README

### DIFF
--- a/ReadMe.md
+++ b/ReadMe.md
@@ -1,4 +1,4 @@
 This repo contains the source material and build tools for: http://www.yaml.org
 
 The upkeep of http://www.yaml.org is a community project. You can easily
-contribute! See [[Contributing.md]] for details.
+contribute! See [Contributing.md](Contributing.md) for details.


### PR DESCRIPTION
The wiki-style syntax in use is not (or is no longer) supported.