### PR TITLE
Add JSON Schema as a validation/schemata option

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -83,6 +83,7 @@
 <span class="yaml_key">Related Projects</span><span class="yaml_key_sep">:</span>
   - <a href="http://rjbs.manxome.org/rx/">Rx</a>            <span class="yaml_comment"># Multi-Language Schemata Tool for JSON/YAML</span>
   - <a href="http://www.kuwata-lab.com/kwalify/">Kwalify</a>       <span class="yaml_comment"># Ruby Schemata Tool for JSON/YAML</span>
+  - <a href="https://json-schema-everywhere.github.io/yaml">JSON Schema</a>   <span class="yaml_comment"># Popular standard for document validation that works with YAML</span>
   - <a href="http://github.com/trans/yaml_vim/tree/master">yaml_vim</a>      <span class="yaml_comment"># vim syntax files for YAML</span>
   - <a href="http://www.codeplex.com/yaml/">yatools.net</a>   <span class="yaml_comment"># Visual Studio editor for YAML</span>
   - <a href="http://json.org/">JSON</a>          <span class="yaml_comment"># Official JSON Website</span>


### PR DESCRIPTION
Add JSON Schema as a validation/schemata option.  Near as I can tell, JSON Schema is the only validation solution that has tooling support.