### PR TITLE
Add links to Gulp-YAML (Gulp plugin for JS-YAML)

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -66,6 +66,7 @@
   <span class="yaml_key">Javascript</span><span class="yaml_key_sep">:</span>
   - <a href="https://github.com/nodeca/js-yaml">JS-YAML</a>       <span class="yaml_comment"># Native PyYAML port to JavaScript.</span>
   - <a href="http://nodeca.github.com/js-yaml/">JS-YAML Online</a><span class="yaml_comment"># Browserified JS-YAML demo, to play with YAML in your browser.</span>
+  - <a href="https://github.com/crissdev/gulp-yaml">Gulp-YAML</a>       <span class="yaml_comment"># Gulp plugin based on JS-YAML.</span>
   <span class="yaml_key">Actionscript</span><span class="yaml_key_sep">:</span>
   - <a href="http://flexonrails.net/">as3yaml</a>       <span class="yaml_comment"># port of JvYAML (1.1)</span>
   <span class="yaml_key">Haskell</span><span class="yaml_key_sep">:</span>

--- a/src/index.html
+++ b/src/index.html
@@ -66,6 +66,7 @@
   <span class="yaml_key">Javascript</span><span class="yaml_key_sep">:</span>
   - <a href="https://github.com/nodeca/js-yaml">JS-YAML</a>       <span class="yaml_comment"># Native PyYAML port to JavaScript.</span>
   - <a href="http://nodeca.github.com/js-yaml/">JS-YAML Online</a><span class="yaml_comment"># Browserified JS-YAML demo, to play with YAML in your browser.</span>
+  - <a href="https://github.com/crissdev/gulp-yaml">Gulp-YAML</a>       <span class="yaml_comment"># Gulp plugin based on JS-YAML.</span>
   <span class="yaml_key">Actionscript</span><span class="yaml_key_sep">:</span>
   - <a href="http://flexonrails.net/">as3yaml</a>       <span class="yaml_comment"># port of JvYAML (1.1)</span>
   <span class="yaml_key">Haskell</span><span class="yaml_key_sep">:</span>


### PR DESCRIPTION
Add links to [`gulp-yaml`](https://github.com/crissdev/gulp-yaml) which is the Gulp plugin for `js-yaml`.