### PR TITLE
 Add Symfony Yaml Component to PHP Projects 

### DIFF
--- a/index.html
+++ b/index.html
@@ -60,6 +60,7 @@
   - <a href="https://github.com/go-yaml/yaml">Go-yaml</a>       <span class="yaml_comment"># YAML support for the Go language.</span>
   - <a href="https://github.com/kylelemons/go-gypsy">Go-gypsy</a>      <span class="yaml_comment"># Simplified YAML parser written in Go.</span>
   <span class="yaml_key">PHP</span><span class="yaml_key_sep">:</span>
+  - <a href="https://symfony.com/doc/current/components/yaml.html">The Yaml Component</a>      <span class="yaml_comment"># Symfony Yaml Component - Loads and dumps YAML files (YAML 1.2)</span>  
   - <a href="http://code.google.com/p/php-yaml/">php-yaml</a>      <span class="yaml_comment"># libyaml bindings (YAML 1.1)</span>
   - <a href="http://pecl.php.net/package/syck">syck</a>          <span class="yaml_comment"># syck bindings (YAML 1.0)</span>
   - <a href="https://github.com/mustangostang/spyc">spyc</a>          <span class="yaml_comment"># yaml loader/dumper (YAML 1.?)</span>


### PR DESCRIPTION
The Symfony Yaml component parses YAML strings to convert them to PHP arrays. It is also able to convert PHP arrays to YAML strings.

The Symfony Yaml Component implements a selected subset of features defined in the YAML 1.2 version specification.

  * [Documentation](https://symfony.com/doc/current/components/yaml/index.html)
  * [Source code](https://github.com/symfony/yaml)