### PR TITLE
Update PECL YAML extension location

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -58,7 +58,7 @@
   - <a href="https://github.com/go-yaml/yaml">Go-yaml</a>       <span class="yaml_comment"># YAML support for the Go language.</span>
   - <a href="https://github.com/kylelemons/go-gypsy">Go-gypsy</a>      <span class="yaml_comment"># Simplified YAML parser written in Go.</span>
   <span class="yaml_key">PHP</span><span class="yaml_key_sep">:</span>
-  - <a href="http://code.google.com/p/php-yaml/">php-yaml</a>      <span class="yaml_comment"># libyaml bindings (YAML 1.1)</span>
+  - <a href="https://pecl.php.net/package/yaml">yaml</a>      <span class="yaml_comment"># libyaml bindings (YAML 1.1)</span>
   - <a href="http://pecl.php.net/package/syck">syck</a>          <span class="yaml_comment"># syck bindings (YAML 1.0)</span>
   - <a href="https://github.com/mustangostang/spyc">spyc</a>          <span class="yaml_comment"># yaml loader/dumper (YAML 1.?)</span>
   <span class="yaml_key">OCaml</span><span class="yaml_key_sep">:</span>

--- a/src/index.html
+++ b/src/index.html
@@ -58,7 +58,7 @@
   - <a href="https://github.com/go-yaml/yaml">Go-yaml</a>       <span class="yaml_comment"># YAML support for the Go language.</span>
   - <a href="https://github.com/kylelemons/go-gypsy">Go-gypsy</a>      <span class="yaml_comment"># Simplified YAML parser written in Go.</span>
   <span class="yaml_key">PHP</span><span class="yaml_key_sep">:</span>
-  - <a href="http://code.google.com/p/php-yaml/">php-yaml</a>      <span class="yaml_comment"># libyaml bindings (YAML 1.1)</span>
+  - <a href="https://pecl.php.net/package/yaml">yaml</a>      <span class="yaml_comment"># libyaml bindings (YAML 1.1)</span>
   - <a href="http://pecl.php.net/package/syck">syck</a>          <span class="yaml_comment"># syck bindings (YAML 1.0)</span>
   - <a href="https://github.com/mustangostang/spyc">spyc</a>          <span class="yaml_comment"># yaml loader/dumper (YAML 1.?)</span>
   <span class="yaml_key">OCaml</span><span class="yaml_key_sep">:</span>


### PR DESCRIPTION
Hello, the PHP's YAML extension has a homepage located in PECL at https://pecl.php.net/package/yaml

This patch updates it from the previous `php-yaml` project at Google code which is now obsolete.

Thank you for checking this out or considering merging it.