### PR TITLE
Update PECL YAML extension location

### DIFF
--- a/index.html
+++ b/index.html
@@ -61,7 +61,7 @@
   - <a href="https://github.com/kylelemons/go-gypsy">Go-gypsy</a>           <span class="yaml_comment"># Simplified YAML parser written in Go.</span>
   <span class="yaml_key">PHP</span><span class="yaml_key_sep">:</span>
   - <a href="https://symfony.com/doc/current/components/yaml.html">The Yaml Component</a> <span class="yaml_comment"># Symfony Yaml Component - Loads and dumps YAML files (YAML 1.2)</span>  
-  - <a href="http://code.google.com/p/php-yaml/">php-yaml</a>           <span class="yaml_comment"># libyaml bindings (YAML 1.1)</span>
+  - <a href="https://pecl.php.net/package/yaml">yaml</a>           <span class="yaml_comment"># libyaml bindings (YAML 1.1)</span>
   - <a href="http://pecl.php.net/package/syck">syck</a>               <span class="yaml_comment"># syck bindings (YAML 1.0)</span>
   - <a href="https://github.com/mustangostang/spyc">spyc</a>               <span class="yaml_comment"># yaml loader/dumper (YAML 1.?)</span>
   <span class="yaml_key">OCaml</span><span class="yaml_key_sep">:</span>


### PR DESCRIPTION
Hello, the PHP's YAML extension has a homepage located in PECL at https://pecl.php.net/package/yaml

This patch updates it from the previous php-yaml project at Google code which is now obsolete.

Thank you for checking this out or considering merging it.

This pull request is the same as #36 but is also targeting the `gh-pages` branch... I'm not sure how things are organized here so feel free to merge or close as needed. Thanks.