### PR TITLE
Add link to github.com/goccy/go-yaml for the Go language

### DIFF
--- a/index.html
+++ b/index.html
@@ -48,6 +48,7 @@
   <span class="yaml_key">Golang</span><span class="yaml_key_sep">:</span>
   - <a href="https://github.com/go-yaml/yaml"                     >Go-yaml</a>            <span class="yaml_comment"># YAML support for the Go language.</span>
   - <a href="https://github.com/kylelemons/go-gypsy"              >Go-gypsy</a>           <span class="yaml_comment"># Simplified YAML parser written in Go.</span>
+  - <a href="https://github.com/goccy/go-yaml"                    >goccy/go-yaml</a>      <span class="yaml_comment"># YAML 1.2 implementation in pure Go.</span>
   <span class="yaml_key">Haskell</span><span class="yaml_key_sep">:</span>
   - <a href="https://hackage.haskell.org/package/HsYAML"          >HsYAML</a>             <span class="yaml_comment"># YAML 1.2 implementation in pure Haskell                           | <a href="#yts" title="Uses YAML Test Suite">YTS</a></span>
   - <a href="https://hackage.haskell.org/package/YamlReference"   >YamlReference</a>      <span class="yaml_comment"># Haskell 1.2 reference parser</span>


### PR DESCRIPTION
Add link to a new library ( https://github.com/goccy/go-yaml ) for the Go language