### PR TITLE
ADD YAMLDiff to related projects

### DIFF
--- a/index.html
+++ b/index.html
@@ -100,6 +100,7 @@
   - <a href="http://json.org/"                            >JSON</a>          <span class="yaml_comment"># Official JSON Website</span>
   - <a href="http://pygments.org/demo/?lang=yaml"         >Pygments</a>      <span class="yaml_comment"># Python language Syntax Colorizer /w YAML support</span>
   - <a href="https://github.com/adrienverge/yamllint"     >yamllint</a>      <span class="yaml_comment"># YAML Linter based on PyYAML</span>
+  - <a href="https://yamldiff.com/"                       >YAML Diff</a>     <span class="yaml_comment"># Semantically compare two YAML documents</span>
 
 <span class="yaml_key">News</span><span class="yaml_key_sep">:</span>
   - 20-NOV-2011 -- <a href="https://github.com/nodeca/js-yaml">JS-YAML</a>, a JavaScript YAML parser by <a href="https://github.com/ixti">Alexey Zapparov</a> and <a href="https://github.com/puzrin">Vitaly Puzrin</a>.


### PR DESCRIPTION
Add yamldiff.com, a small site to semantically compare YAML documents.