### PR TITLE
Correct link to js-yaml demo page.

### DIFF
--- a/index.html
+++ b/index.html
@@ -58,7 +58,7 @@
   - <a href="https://github.com/EsotericSoftware/yamlbeans"       >YamlBeans</a>          <span class="yaml_comment"># To/from JavaBeans. YAML 1.0/1.1</span>
   - <a href="https://github.com/decorators-squad/eo-yaml"         >eo-yaml</a>            <span class="yaml_comment"># YAML 1.2 for Java 8. Also packaged as a Module (Java 9+).</span>
   <span class="yaml_key">Javascript</span><span class="yaml_key_sep">:</span>
-  - <a href="https://github.com/nodeca/js-yaml"                   >js-yaml</a>            <span class="yaml_comment"># Native PyYAML port to JavaScript. <a href="http://nodeca.github.com/js-yaml/">Demo</a></span>
+  - <a href="https://github.com/nodeca/js-yaml"                   >js-yaml</a>            <span class="yaml_comment"># Native PyYAML port to JavaScript. <a href="https://nodeca.github.io/js-yaml/">Demo</a></span>
   - <a href="https://github.com/eemeli/yaml"                      >yaml</a>               <span class="yaml_comment"># JavaScript parser and stringifier (YAML 1.2, 1.1)                 | <a href="#yts" title="Uses YAML Test Suite">YTS</a></span>
   <span class="yaml_key">Nim</span><span class="yaml_key_sep">:</span>
   - <a href="https://nimyaml.org"                                 >NimYAML</a>            <span class="yaml_comment"># YAML 1.2 implementation in pure Nim                               | <a href="#yts" title="Uses YAML Test Suite">YTS</a></span>


### PR DESCRIPTION
https://nodeca.github.io/js-yaml/

Fixes: #77 