### PR TITLE
add markdownlint config

### DIFF
--- a/.markdownlint.yaml
+++ b/.markdownlint.yaml
@@ -1,0 +1,2 @@
+MD034: false
+MD003: false


### PR DESCRIPTION
Gets rid of a couple of warnings based on what is clearly intended style.