### PR TITLE
Removing the CNAME file

### DIFF
--- a/CNAME
+++ b/CNAME
@@ -1,1 +1,0 @@
-yaml.org


### PR DESCRIPTION
CNAME files are no longer needed afaict.

And they trigger warnings on forks.
