### PR TITLE
Underline term links

### DIFF
--- a/tags/1.2/single_html.css
+++ b/tags/1.2/single_html.css
@@ -226,7 +226,7 @@ a[href^="#"] {
   text-decoration: none;
   color: black;
   background-color: green;
-  background: url(term.png) no-repeat bottom right;
+  background: url(term.png) repeat-x bottom right;
 }
 
 a[href^="#"]:hover,


### PR DESCRIPTION
The current "underline" is only at the right end of the link (confusingly, when hovered, the underline is across the entire link), making it difficult to determine which words are included in the term.