### PR TITLE
Add Yams

### DIFF
--- a/index.html
+++ b/index.html
@@ -89,6 +89,8 @@
   <span class="yaml_key">Rust</span><span class="yaml_key_sep">:</span>
   - <a href="https://github.com/chyh1990/yaml-rust"               >yaml-rust</a>          <span class="yaml_comment"># YAML 1.2 implementation in pure Rust</span>
   - <a href="https://github.com/dtolnay/serde-yaml"               >serde-yaml</a>         <span class="yaml_comment"># YAML de/serialization of structs</span>
+  <span class="yaml_key">Swift</span><span class="yaml_key_sep">:</span>
+  - <a href="https://github.com/jpsim/Yams"                       >Yams</a>               <span class="yaml_comment"># libyaml wrapper</span>
   <span class="yaml_key">Others</span><span class="yaml_key_sep">:</span>
   - <a href="http://www.vim.org/scripts/script.php?script_id=3190">yamlvim</a> <a href="http://yamlvim.hg.sourceforge.net/hgweb/yamlvim/yamlvim/">(src)</a>      <span class="yaml_comment"># YAML dumper/emitter in pure vimscript</span>
 


### PR DESCRIPTION
[Yams](https://github.com/jpsim/Yams) is the de-facto standard for Yaml
parsing in Swift and is even used in parts of the Swift compiler tooling
itself.