### PR TITLE
Add ocaml-yaml as more modern YAML option

### DIFF
--- a/index.html
+++ b/index.html
@@ -63,6 +63,7 @@
   <span class="yaml_key">Nim</span><span class="yaml_key_sep">:</span>
   - <a href="https://nimyaml.org"                                 >NimYAML</a>            <span class="yaml_comment"># YAML 1.2 implementation in pure Nim                               | <a href="#yts" title="Uses YAML Test Suite">YTS</a></span>
   <span class="yaml_key">OCaml</span><span class="yaml_key_sep">:</span>
+  - <a href="https://github.com/avsm/ocaml-yaml"                  >ocaml-yaml</a>         <span class="yaml_comment"># YAML 1.1/1.2 via libyaml bindings</span>
   - <a href="http://ocaml-syck.sourceforge.net"                   >ocaml-syck</a>         <span class="yaml_comment"># YAML 1.0 via syck bindings</span>
   <span class="yaml_key">Perl Modules</span><span class="yaml_key_sep">:</span>
   - <a href="https://metacpan.org/release/YAML"                   >YAML</a>               <span class="yaml_comment"># Pure Perl YAML 1.0 Module</span>


### PR DESCRIPTION
ocaml-yaml is a maintained YAML 1.1/1.2 library for OCaml available on opam https://opam.ocaml.org/packages/yaml/

As an aside the ocaml-syck library does exist but is not available in the OPAM package repository.
So it wouldn't be as accessible an option for people in OCaml to use YAML.