### PR TITLE
Add a section dedicated to community tools around yaml

### DIFF
--- a/ReadMe.md
+++ b/ReadMe.md
@@ -6,3 +6,10 @@ This repo contains the source material and build tools for <https://yaml.org>.
 The upkeep of https://yaml.org is a community project.
 You can easily contribute!
 See [the Contribution guide](Contributing.md) for details.
+
+# 🧑‍🤝‍🧑 Community driven projects around `yaml`
+
+Find below a set of Open Source community tools around `yaml` : 
+
+- [`yamlfixer`](https://github.com/opt-nc/yamlfixer) : automates the fixing of problems reported by yamllint by parsing its output.
+- [`ytt`](https://github.com/vmware-tanzu/carvel-ytt) : `YAML` templating tool that works on YAML structure instead of text  


### PR DESCRIPTION
Maybe would you be interted in adding section dedicated to Open source community tools aournd `yaml`

cf https://github.com/opt-nc/yamlfixer/issues/53