### PR TITLE
Add yamlfixer to the Python section

### DIFF
--- a/index.html
+++ b/index.html
@@ -129,6 +129,7 @@
   - <a href="https://pypi.python.org/pypi/ruamel.yaml"            >ruamel.yaml</a>   <span class="ycom"># YAML 1.2, update of PyYAML; comments round-trip</span>
   - <a href="https://github.com/yaml/pysyck"                      >PySyck</a>        <span class="ycom"># YAML 1.0, syck binding</span>
   - <a href="https://pypi.org/project/strictyaml/"                >strictyaml</a>    <span class="ycom"># Restricted YAML subset</span>
+  - <a href="https://github.com/opt-nc/yamlfixer"                >yamlfixer</a>    <span class="ycom"># Automates the fixing of problems reported by yamllint by parsing its output</span>
 
   <span class="ykey">R</span><span class="ysep">:</span>
   - <a href="https://github.com/viking/r-yaml"                    >R YAML</a>        <span class="ycom"># libyaml wrapper</span>


### PR DESCRIPTION
Hi guys, we have been working on a Python tool that "Automates the fixing of problems reported by yamllint by parsing its output"
So it could be cool to get it on th website :smile_cat: 

Hopefully you'll like it :crossed_fingers:

related to https://github.com/opt-nc/yamlfixer/issues/53