### PR TITLE
Remove trailing space

### DIFF
--- a/index.html
+++ b/index.html
@@ -158,7 +158,7 @@
 
 <span class="ykey">Related Projects</span><span class="ysep">:</span>
   - <a href="http://rjbs.manxome.org/rx/"                 >Rx</a>            <span class="ycom"># Multi-Language Schemata Tool for JSON/YAML</span>
-  - <a href="ihttps://www.rubydoc.info/gems/kwalify/"     >Kwalify</a>       <span class="ycom"># Ruby Schemata Tool for JSON/YAML</span> <!--  - <a href="http://github.com/trans/yaml_vim/tree/master">yaml_vim</a>      <span class="ycom"># vim syntax files for YAML</span> -->
+  - <a href="ihttps://www.rubydoc.info/gems/kwalify/"     >Kwalify</a>       <span class="ycom"># Ruby Schemata Tool for JSON/YAML</span><!--  - <a href="http://github.com/trans/yaml_vim/tree/master">yaml_vim</a>      <span class="ycom"># vim syntax files for YAML</span> -->
   - <a href="https://github.com/Grokzen/pykwalify"        >pyKwalify</a>     <span class="ycom"># Python Schemata Tool for JSON/YAML</span>
   - <a href="http://www.codeplex.com/yaml/"               >yatools.net</a>   <span class="ycom"># Visual Studio editor for YAML</span>
   - <a href="http://json.org/"                            >JSON</a>          <span class="ycom"># Official JSON Website</span>


### PR DESCRIPTION
I noticed this when passing to yamlpp-highlight which highlights lines with trailing spaces differently