### PR TITLE
Remove pysyck

### DIFF
--- a/index.html
+++ b/index.html
@@ -127,7 +127,6 @@
   <span class="ykey">Python</span><span class="ysep">:</span>
   - <a href="http://pyyaml.org"                                   >PyYAML</a>        <span class="ycom"># YAML 1.1, pure python and libyaml binding</span>
   - <a href="https://pypi.python.org/pypi/ruamel.yaml"            >ruamel.yaml</a>   <span class="ycom"># YAML 1.2, update of PyYAML; comments round-trip</span>
-  - <a href="https://github.com/yaml/pysyck"                      >PySyck</a>        <span class="ycom"># YAML 1.0, syck binding</span>
   - <a href="https://pypi.org/project/strictyaml/"                >strictyaml</a>    <span class="ycom"># Restricted YAML subset</span>
 
   <span class="ykey">R</span><span class="ysep">:</span>


### PR DESCRIPTION
pysyck is no longer available …
The [github repository](https://github.com/yaml/pysyck) has been deleted