### PR TITLE
Correct name of Go programming language

### DIFF
--- a/index.html
+++ b/index.html
@@ -83,7 +83,7 @@
   <span class="ykey">Erlang</span><span class="ysep">:</span>
   - <a href="https://github.com/yakaz/yamerl"                     >yamerl</a>        <span class="ycom"># YAML support for the Erlang language</span>
 
-  <span class="ykey">Golang</span><span class="ysep">:</span>
+  <span class="ykey">Go</span><span class="ysep">:</span>
   - <a href="https://github.com/go-yaml/yaml"                     >Go-yaml</a>       <span class="ycom"># YAML support for the Go language</span>
   - <a href="https://github.com/kylelemons/go-gypsy"              >Go-gypsy</a>      <span class="ycom"># Simplified YAML parser written in Go</span>
   - <a href="https://github.com/goccy/go-yaml"                    >goccy/go-yaml</a> <span class="ycom"># YAML 1.2 implementation in pure Go</span>


### PR DESCRIPTION
The language is named Go

See their FAQ - https://go.dev/doc/faq#go_or_golang