### PR TITLE
Add `yq` to list of related projects

### DIFF
--- a/index.html
+++ b/index.html
@@ -166,6 +166,7 @@
   - <a href="https://github.com/adrienverge/yamllint"     >yamllint</a>      <span class="ycom"># YAML Linter based on PyYAML</span>
   - <a href="https://yamldiff.com/"                       >YAML Diff</a>     <span class="ycom"># Semantically compare two YAML documents</span>
   - <a href="https://json-schema-everywhere.github.io/yaml">JSON Schema</a>   <span class="ycom"># YAML-compliant JSON standard for data validation</span>
+  - <a href="https://github.com/mikefarah/yq"             >Yq</a>            <span class="ycom"># Command-line YAML processor</span>
 <!--
 <span class="ykey">News</span><span class="ysep">:</span>
   - 20-NOV-2011 -- <a href="https://github.com/nodeca/js-yaml">JS-YAML</a>, a JavaScript YAML parser by <a href="https://github.com/ixti">Alexey Zapparov</a> and <a href="https://github.com/puzrin">Vitaly Puzrin</a>.


### PR DESCRIPTION
"Yq" is a lightweight YAML (and other) command-line processor. List it under "related projects" in yaml.org front page.