### PR TITLE
Fixed link to YAML Test Matrix

### DIFF
--- a/index.html
+++ b/index.html
@@ -50,7 +50,7 @@
   - <a href="https://github.com/yaml/yaml-reference-parser">Generated Reference Parsers</a>
   - <a href="http://ben-kiki.org/ypaste">YPaste Interactive Parser</a>
 
-  <span class="ykey">YAML Test Matrix</span><span class="ysep">:</span>   <a href="https://matrix.yaml.io/">matrix.yaml.io</a>
+  <span class="ykey">YAML Test Matrix</span><span class="ysep">:</span>   <a href="https://matrix.yaml.info">matrix.yaml.info</a>
 <!--  <span class="ykey">YAML Docker Runtimes</span><span class="ysep">:</span> <a href="https://github.com/yaml/yaml-runtimes">/yaml-runtimes</a>
   <span class="ykey">YAML Cookbook (Ruby)</span><span class="ysep">:</span> <a href="YAML_for_ruby.html">YAML_for_ruby.html</a> --><!-- http://yaml4r.sourceforge.net/cookbook/ --><!--
 -->


### PR DESCRIPTION
## Update: 
- Updated link from: [https://matrix.yaml.io/](https://matrix.yaml.io/)
- To: [https://matrix.yaml.info](https://matrix.yaml.info)

Closes #150 

🖖 