### PR TITLE
Fixed page redirect for yamlvim : YAML dumper/emitter in pure vimscript

### DIFF
--- a/index.html
+++ b/index.html
@@ -154,7 +154,7 @@
   - <a href="https://github.com/jpsim/Yams"                       >Yams</a>          <span class="ycom"># libyaml wrapper</span>
 
   <span class="ykey">Others</span><span class="ysep">:</span>
-  - <a href="http://www.vim.org/scripts/script.php?script_id=3191">yamlvim</a>       <span class="ycom"># YAML dumper/emitter in pure vimscript</span>
+  - <a href="http://www.vim.org/scripts/script.php?script_id=3190">yamlvim</a>       <span class="ycom"># YAML dumper/emitter in pure vimscript</span>
 
 <span class="ykey">Related Projects</span><span class="ysep">:</span>
   - <a href="http://rjbs.manxome.org/rx/"                 >Rx</a>            <span class="ycom"># Multi-Language Schemata Tool for JSON/YAML</span>


### PR DESCRIPTION
Previous url redirected to `DokuVimKi : Allows to edit DokuWiki pages via XMLRPC`