### PR TITLE
Update Go-yaml link to yaml/go-yaml repo

### DIFF
--- a/index.html
+++ b/index.html
@@ -84,7 +84,7 @@
   - <a href="https://github.com/yakaz/yamerl"                     >yamerl</a>        <span class="ycom"># YAML support for the Erlang language</span>
 
   <span class="ykey">Golang</span><span class="ysep">:</span>
-  - <a href="https://github.com/go-yaml/yaml"                     >Go-yaml</a>       <span class="ycom"># YAML support for the Go language</span>
+  - <a href="https://github.com/yaml/go-yaml"                     >Go-yaml</a>       <span class="ycom"># YAML support for the Go language</span>
   - <a href="https://github.com/kylelemons/go-gypsy"              >Go-gypsy</a>      <span class="ycom"># Simplified YAML parser written in Go</span>
   - <a href="https://github.com/goccy/go-yaml"                    >goccy/go-yaml</a> <span class="ycom"># YAML 1.2 implementation in pure Go</span>
 


### PR DESCRIPTION
The `go-yaml\yaml` repo is archived and is not maintained anymore. The project has been forked now officially supported by yaml org.

Fixes: https://github.com/yaml/go-yaml/issues/32