### PR TITLE
Add YAML parser for Poly/ML to libraries.yaml

### DIFF
--- a/src/libraries.yaml
+++ b/src/libraries.yaml
@@ -302,6 +302,12 @@ MATLAB:
   site: https://github.com/NeuroJSON/jsonlab
   icon: material-code-braces
 
+ML:
+- name: Yaml-Parser-in-PolyML
+  desc: A YAML parser written for Poly/ML in Standard ML
+  site: https://www.polyml.org/software/details.php?id=48
+  icon: material-code-braces
+
 Nim:
 - name: NimYAML
   desc: YAML 1.2 implementation in pure Nim


### PR DESCRIPTION
Implemented a YAML Parser for Standard ML Language. Currently 20% Test coverage from a subset of YAML Test Suite has been achieved and is still in development and requires more coverage from YAML-Test-Suite. The high-level API currently includes file I/O, recursive key search, and pretty printing. 