### PR TITLE
Security: replace Polyfill.io CDN with Cloudflare CDN

### DIFF
--- a/mkdocs.yaml
+++ b/mkdocs.yaml
@@ -103,7 +103,7 @@ extra_css:
 
 extra_javascript:
 - js/mathjax.js
-- https://polyfill.io/v3/polyfill.min.js?features=es6
+- https://cdnjs.cloudflare.com/polyfill/v3/polyfill.min.js?version=4.8.0&features=es6
 - https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js
 
 # Copyright


### PR DESCRIPTION
Polyfill.io was associated with a supply-chain security incident in 2024, where the service was found to potentially serve altered or malicious scripts after changes in ownership.

The code now uses Cloudflare’s CDN instead of the previously compromised Polyfill.io CDN to improve security and reliability.

As of 2026-05-31, visiting yaml.org may show a login prompt related to the Polyfill.io script issue, as seen below:

<img width="1271" height="1036" alt="image" src="https://github.com/user-attachments/assets/8cdd286c-a953-4b74-921b-4da80259ee6a" />

<img width="1391" height="1051" alt="image" src="https://github.com/user-attachments/assets/8a470a0b-487e-4303-a4d5-b4e12335c0cf" />

References:

 - https://blog.cloudflare.com/automatically-replacing-polyfill-io-links-with-cloudflares-mirror-for-a-safer-internet/#how-we-came-to-this-decision
- https://sansec.io/research/polyfill-supply-chain-attack