### PR TITLE
Add YAML Preflight to web tools

### DIFF
--- a/src/tools.yaml
+++ b/src/tools.yaml
@@ -27,6 +27,11 @@ Utilities:
   type: web
 
 Linters & Validators:
+- name: YAML Preflight
+  desc: Browser-local strict YAML and GitHub Actions permissions preflight
+  site: https://yaml.aevumere.com/yaml-preflight?source=yaml-org
+  icon: material-code-tags-check
+  type: web
 - name: yamllint
   desc: YAML Linter based on PyYAML
   site: https://github.com/adrienverge/yamllint


### PR DESCRIPTION
Adds YAML Preflight to Linters & Validators. It checks strict YAML and a narrow set of GitHub Actions permissions in the browser; pasted YAML is not sent to the server. I maintain the tool.